### PR TITLE
Remove installation of nightly toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,7 @@ RUN apt-get update && \
     libudev-dev \
     xorg-dev
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust_install.sh && \
-    sh rust_install.sh -y && \
-    rm rust_install.sh && \
-    source ~/.cargo/env && \
-    rustup install nightly-2021-03-04
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN source ~/.cargo/env && \
     cargo install cargo-tarpaulin


### PR DESCRIPTION
https://github.com/openrr/openrr/pull/323 is currently encountering an error due to a cargo bug that was fixed in https://github.com/rust-lang/cargo/pull/9229.
https://github.com/openrr/openrr/runs/2671887902?check_suite_focus=true

So, update to the latest nightly that includes https://github.com/rust-lang/cargo/pull/9229.